### PR TITLE
[libpng]: Add inspec tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,15 @@
-# base-plan-skeleton
-Template for all new Chef Base Plans to simplify creation of repositories.
+# libpng
+
+An Open, Extensible Image Format with Lossless Compression
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://dev.azure.com/chefcorp-partnerengineering/Chef%20Base%20Plans/_apis/build/status/chef-base-plans.libpng?branchName=master)](https://dev.azure.com/chefcorp-partnerengineering/Chef%20Base%20Plans/_build/latest?definitionId=69&branchName=master)
+
 # libpng
 
 An Open, Extensible Image Format with Lossless Compression

--- a/attributes.yml
+++ b/attributes.yml
@@ -1,0 +1,2 @@
+library_filename: 'libpng.so'
+pkgconfig_filename: 'libpng.pc'

--- a/controls/libpng_library_exists.rb
+++ b/controls/libpng_library_exists.rb
@@ -1,0 +1,39 @@
+title 'Tests to confirm libpng library exists'
+
+plan_origin = ENV['HAB_ORIGIN']
+plan_name = input('plan_name', value: 'libpng')
+
+control 'core-plans-libpng-library-exists' do
+  impact 1.0
+  title 'Ensure libpng library exists'
+  desc '
+  Verify libpng library by ensuring that 
+  (1) its installation directory exists; 
+  (2) the library exists; 
+  (3) its pkgconfig metadata contains the expected version
+  '
+  
+  plan_installation_directory = command("hab pkg path #{plan_origin}/#{plan_name}")
+  describe plan_installation_directory do
+    its('exit_status') { should eq 0 }
+    its('stdout') { should_not be_empty }
+  end
+
+  library_filename = input('library_filename', value: 'libpng.so')
+  library_full_path = File.join(plan_installation_directory.stdout.strip, 'lib', "#{library_filename}")
+  describe file(library_full_path) do
+    it { should exist }
+  end
+
+  plan_pkg_ident = ((plan_installation_directory.stdout.strip).match /(?<=pkgs\/)(.*)/)[1]
+  plan_pkg_version = (plan_pkg_ident.match /^#{plan_origin}\/#{plan_name}\/(?<version>.*)\//)[:version]
+  pkgconfig_filename = input('pkgconfig_filename', value: 'libpng.pc')
+  pkgconfig_full_path = File.join(plan_installation_directory.stdout.strip, 'lib', 'pkgconfig', "#{pkgconfig_filename}")
+  describe command("cat #{pkgconfig_full_path}") do
+    its('exit_status') { should eq 0 }
+    its('stdout') { should_not be_empty }
+    its('stdout') { should match /Name:\s+libpng/ }
+    its('stdout') { should match /Version:\s+#{plan_pkg_version}/ }
+    its('stderr') { should be_empty }
+  end
+end

--- a/inspec.yml
+++ b/inspec.yml
@@ -1,9 +1,9 @@
-name: {{plan_name}}
-title: Habitat Core Plan {{plan_name}}
-maintainer: humans@habitat.sh
-summary: InSpec controls for testing Habitat Core Plan {{plan_name}}
-copyright: humans@habitat.sh
-copyright_email: humans@habitat.sh
+name: libpng
+title: Habitat Core Plan libpng
+maintainer: "The Habitat Maintainers <humans@habitat.sh>"
+summary: InSpec controls for testing Habitat Core Plan libpng
+copyright: 2019, Chef Software, Inc.
+copyright_email: legal@chef.io
 version: 0.1.0
 license: Apache-2.0
 inspec_version: '>= 3.0.25'

--- a/plan.sh
+++ b/plan.sh
@@ -1,0 +1,41 @@
+pkg_name=libpng
+pkg_version=1.6.37
+pkg_origin=core
+pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
+pkg_license=("libpng")
+pkg_description="An Open, Extensible Image Format with Lossless Compression"
+pkg_upstream_url=http://www.libpng.org/pub/png/
+pkg_source="http://download.sourceforge.net/${pkg_name}/${pkg_name}-${pkg_version}.tar.gz"
+pkg_filename="${pkg_name}-${pkg_version}.tar.gz"
+pkg_shasum=daeb2620d829575513e35fecc83f0d3791a620b9b93d800b763542ece9390fb4
+pkg_deps=(
+  core/glibc
+  core/zlib
+)
+pkg_build_deps=(
+  core/gcc
+  core/make
+  core/coreutils
+  core/diffutils
+  core/autoconf
+  core/automake
+)
+pkg_bin_dirs=(bin)
+pkg_include_dirs=(include)
+pkg_lib_dirs=(lib)
+
+do_build() {
+  _zlib_dir=$(pkg_path_for zlib)
+
+  ./configure \
+    --prefix="${pkg_prefix}" \
+    --host=x86_64-unknown-linux-gnu \
+    --build=x86_64-unknown-linux-gnu \
+    --disable-static \
+    --with-zlib-prefix="${_zlib_dir}"
+  make
+}
+
+do_check() {
+  make test
+}


### PR DESCRIPTION


```rspec
hab pkg exec chef/inspec inspec exec /src/. --chef-license=accept -t docker://8b4fd5d718e086822c8d854f40819765b57e4973a5b275d753f99aebf663e3f4 --input-file /src/attributes.yml

Profile: Habitat Core Plan libpng (libpng)
Version: 0.1.0
Target:  docker://8b4fd5d718e086822c8d854f40819765b57e4973a5b275d753f99aebf663e3f4

  ✔  core-plans-libpng-library-exists: Ensure libpng library exists
     ✔  Command: `hab pkg path core/libpng` exit_status is expected to eq 0
     ✔  Command: `hab pkg path core/libpng` stdout is expected not to be empty
     ✔  File /hab/pkgs/core/libpng/1.6.37/20200615131431/lib/libpng.so is expected to exist
     ✔  Command: `cat /hab/pkgs/core/libpng/1.6.37/20200615131431/lib/pkgconfig/libpng.pc` exit_status is expected to eq 0
     ✔  Command: `cat /hab/pkgs/core/libpng/1.6.37/20200615131431/lib/pkgconfig/libpng.pc` stdout is expected not to be empty
     ✔  Command: `cat /hab/pkgs/core/libpng/1.6.37/20200615131431/lib/pkgconfig/libpng.pc` stdout is expected to match /Name:\s+libpng/
     ✔  Command: `cat /hab/pkgs/core/libpng/1.6.37/20200615131431/lib/pkgconfig/libpng.pc` stdout is expected to match /Version:\s+1.6.37/
     ✔  Command: `cat /hab/pkgs/core/libpng/1.6.37/20200615131431/lib/pkgconfig/libpng.pc` stderr is expected to be empty


Profile Summary: 1 successful control, 0 control failures, 0 controls skipped
Test Summary: 8 successful, 0 failures, 0 skipped
+ set +x
[10][default:/src:0]# 
```